### PR TITLE
Migrated to the new base image

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,14 +1,9 @@
 # Use a minimal base image
-FROM slough-dev-dc-generic-base:0.0.1 AS base
+FROM slough-dev-dc-generic-base:0.0.3 AS base
 
 # Install Node.js
-RUN sudo apk add libstdc++
-RUN wget https://unofficial-builds.nodejs.org/download/release/v21.7.3/node-v21.7.3-linux-x64-musl.tar.gz
-RUN sudo mkdir -p /opt/nodejs
-RUN sudo tar -zxvf *.tar.gz --directory /opt/nodejs --strip-components=1
-RUN rm *.tar.gz
-RUN sudo ln -s /opt/nodejs/bin/node /usr/local/bin/node
-RUN sudo ln -s /opt/nodejs/bin/npm /usr/local/bin/npm
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | sudo bash - && \
+    sudo apt-get install -y nodejs
 
 # Configure Starship
 ENV PROMPTNAME="NODEJS"


### PR DESCRIPTION
This base image is based of a Debian base image instead of Alpine, so I had to update the commands to install NodeJS as well.